### PR TITLE
Updated the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 - Run `rnpm link`
 
 Or you can combine 2 commands
-- Run `rnpm install react-native-fcm --save`
+- Run `rnpm install react-native-fcm`
 
 ## Android Configuration
 


### PR DESCRIPTION
When you pass the --save option to rnpm, it throws the error. By default rnpm will add the dependancy.