### PR TITLE
Delete unnecessary onNewIntent method override

### DIFF
--- a/android/src/main/java/com/evollu/react/fcm/FIRMessagingModule.java
+++ b/android/src/main/java/com/evollu/react/fcm/FIRMessagingModule.java
@@ -155,9 +155,4 @@ public class FIRMessagingModule extends ReactContextBaseJavaModule implements Li
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
     }
-
-    @Override
-    public void onNewIntent(Intent intent){
-        sendEvent("FCMNotificationReceived", parseIntent(intent));
-    }
 }


### PR DESCRIPTION
Fix errors below

```
Error:/Users/alma/Development/ltcs/node_modules/react-native-fcm/android/src/main/java/com/evollu/react/fcm/FIRMessagingModule.java:159: error: method does not override or implement a method from a supertype
    @Override
    ^
Note: /Users/alma/Development/ltcs/node_modules/react-native-fcm/android/src/main/java/com/evollu/react/fcm/FIRMessagingModule.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 error
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':react-native-fcm:compileReleaseJavaWithJavac'.
> Compilation failed; see the compiler error output for details.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.
```

---

I'm have no experience at Android nor Java. Please review this PR.