### PR TITLE
exposes the notification title and body to javascript in foreground apps

### DIFF
--- a/android/src/main/java/com/evollu/react/fcm/FIRMessagingModule.java
+++ b/android/src/main/java/com/evollu/react/fcm/FIRMessagingModule.java
@@ -91,25 +91,36 @@ public class FIRMessagingModule extends ReactContextBaseJavaModule implements Li
     }
 
     private void registerMessageHandler() {
+        Log.d(TAG, "registerMessageHandler");
         IntentFilter intentFilter = new IntentFilter("com.evollu.react.fcm.ReceiveNotification");
 
         getReactApplicationContext().registerReceiver(new BroadcastReceiver() {
             @Override
             public void onReceive(Context context, Intent intent) {
-            if (getReactApplicationContext().hasActiveCatalystInstance()) {
-                RemoteMessage message = intent.getParcelableExtra("data");
-                WritableMap params = Arguments.createMap();
-                if(message.getData() != null){
-                    Map data = message.getData();
-                    Set<String> keysIterator = data.keySet();
-                    for(String key: keysIterator){
-                        params.putString(key, (String) data.get(key));
+                if (getReactApplicationContext().hasActiveCatalystInstance()) {
+                    RemoteMessage message = intent.getParcelableExtra("data");
+                    String title = message.getNotification().getTitle();
+                    String body = message.getNotification().getBody();
+                    WritableMap params = Arguments.createMap();
+                    if (message.getData() != null){
+                        Map data = message.getData();
+                        WritableMap wrapper = Arguments.createMap();
+                        Set<String> keysIterator = data.keySet();
+                        for(String key: keysIterator){
+                            wrapper.putString(key, (String) data.get(key));
+                        }
+                        params.putMap("data", wrapper);
                     }
+                    if (title != null) {
+                        params.putString("title", title);
+                    }
+                    if (body != null) {
+                        params.putString("body", body);
+                    }
+                    Log.d(TAG, "FCMNotificationReceived: " + String.valueOf(params));
                     sendEvent("FCMNotificationReceived", params);
                     abortBroadcast();
                 }
-
-            }
             }
         }, intentFilter);
     }


### PR DESCRIPTION
I have run this though with several different types of messages from the Firebase console, and it seems to be working every time...  I realize if anyone is currently keying off of the 'notifications' event then the data will now be nested:
```javascript
data: {key, value}
```

so just be mindful...

![big-lebowski-wait-on-couch](https://cloud.githubusercontent.com/assets/4606770/17413122/8db53258-5a45-11e6-9588-34fc4fa3c88a.gif)
