### PR TITLE
Firestack compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 build
+xcuserdata

--- a/ios/RNFIRMessaging.h
+++ b/ios/RNFIRMessaging.h
@@ -1,7 +1,8 @@
 
 #import <UIKit/UIKit.h>
 
-#import "Firebase.h"
+@import Firebase;
+@import FirebaseMessaging;
 
 #import "RCTBridgeModule.h"
 

--- a/ios/RNFIRMessaging.xcodeproj/project.pbxproj
+++ b/ios/RNFIRMessaging.xcodeproj/project.pbxproj
@@ -217,6 +217,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../../react-native/React/**",
 					"$(SRCROOT)/../../../ios/**",
+					"$(SRCROOT)/../../../node_modules/react-native-firestack/ios/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
@@ -237,6 +238,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../../react-native/React/**",
 					"$(SRCROOT)/../../../ios/**",
+					"$(SRCROOT)/../../../node_modules/react-native-firestack/ios/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";

--- a/ios/RNFIRMessaging.xcodeproj/project.pbxproj
+++ b/ios/RNFIRMessaging.xcodeproj/project.pbxproj
@@ -212,6 +212,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/../../../ios/**",
+					"$(SRCROOT)/../../../node_modules/react-native-firestack/ios/**",
 				);
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = (
@@ -234,6 +235,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/../../../ios/**",
+					"$(SRCROOT)/../../../node_modules/react-native-firestack/ios/**",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../../react-native/React/**",


### PR DESCRIPTION
In case someone also decides to use firestack (https://github.com/fullstackreact/react-native-firestack), that comes prepackaged with most of the Firebase libraries.  This PR just adds the Firestack directories to the search paths so that if they have this set up it'll pick up the frameworks from there.  It shouldn't affect things if you still want to install the frameworks via cocoapods as those paths are still there.