### PR TITLE
Fix build with react-native 0.33

### DIFF
--- a/android/src/main/java/com/evollu/react/fcm/FIRMessagingModule.java
+++ b/android/src/main/java/com/evollu/react/fcm/FIRMessagingModule.java
@@ -1,5 +1,6 @@
 package com.evollu.react.fcm;
 
+import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Intent;
 import android.content.IntentFilter;
@@ -155,7 +156,7 @@ public class FIRMessagingModule extends ReactContextBaseJavaModule implements Li
     }
 
     @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+    public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
     }
 
     @Override


### PR DESCRIPTION
The signature of `onActivityResult` changed in react-native@0.33, it now passes the Activity as the first parameter.

Tested by making changes locally in an app using react-native@0.33.0-rc.0