### PR TITLE
Prevent NullPointerException in onNewIntent

### DIFF
--- a/android/src/main/java/com/evollu/react/fcm/FIRMessagingModule.java
+++ b/android/src/main/java/com/evollu/react/fcm/FIRMessagingModule.java
@@ -190,7 +190,7 @@ public class FIRMessagingModule extends ReactContextBaseJavaModule implements Li
     @Override
     public void onNewIntent(Intent intent){
         Bundle bundle = intent.getExtras();
-        Boolean isLocalNotification = bundle.getBoolean("localNotification", false);
+        Boolean isLocalNotification = bundle != null && bundle.getBoolean("localNotification", false);
         sendEvent(isLocalNotification ? "FCMLocalNotificationReceived" : "FCMNotificationReceived", parseIntent(intent));
     }
 }


### PR DESCRIPTION
If application activity is singleTop and minimized/restored from launcher icon -- in that case activity is reused and intent.getExtras() returns null.