### PR TITLE
Add basic LED blinking support for local notifications on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ class App extends Component {
             tag: 'some_tag',                                    // Android only
             group: "group",                                     // Android only
             my_custom_data:'my_custom_field_value',             // extra data you want to throw
+            lights: true,                                       // Android only, LED blinking (default false)
         });
  
         FCM.scheduleLocalNotification({

--- a/android/src/main/java/com/evollu/react/fcm/FIRLocalMessagingHelper.java
+++ b/android/src/main/java/com/evollu/react/fcm/FIRLocalMessagingHelper.java
@@ -150,6 +150,11 @@ public class FIRLocalMessagingHelper {
                 }
             }
 
+            //lights
+            if (bundle.getBoolean("lights")) {
+                notification.setDefaults(NotificationCompat.DEFAULT_LIGHTS);
+            }
+
             if(mIsForeground){
                 Log.d(TAG, "App is in foreground, broadcast intent instead");
                 Intent i = new Intent("com.evollu.react.fcm.ReceiveLocalNotification");


### PR DESCRIPTION
It would be possible to customize even more the parameters of the LED blinking using [setLights](https://developer.android.com/reference/android/support/v4/app/NotificationCompat.Builder.html#setLights(int, int, int)) but I was happy with the default one.