### PR TITLE
Additional steps to edit MainApplicaiton .java

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,30 @@ If you are using RN < 0.30.0 and react-native-fcm < 1.0.16, pass intent into pac
 +   }       
 ```
 
+You will also need to add these to the list of packages in `MainApplication.java`
+
+Edit `MainApplication.java`
+
+```diff
+import android.app.application
+...
++import com.evollu.react.fcm.FIRMessagingPackage;
+```
+....
+```diff
+    @Override
+    protected List<ReactPackage> getPackages() {
+      return Arrays.<ReactPackage>asList(
+          new MainReactPackage(),
+          new VectorIconsPackage(),
++         new FIRMessagingPackage(),
+          new RNDeviceInfo(),
+      );
+    }
+ ```   
+
+
+
 - RN <= 0.27:
 
 ```diff


### PR DESCRIPTION
I was having build problems and was not able to use the underlying `FIRMessaging` object until I made this change. I think adding this in the README in the actual setup will help folks avoid this problem in the future.
