### PR TITLE
Fixed typo that caused XCode error: undeclared identifier userInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Edit `AppDelegate.m`:
 +
 + //You can skip this method if you don't want to use local notification
 + -(void)application:(UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification {
-+   [[NSNotificationCenter defaultCenter] postNotificationName:FCMNotificationReceived object:self + userInfo:notification.userInfo];
++   [[NSNotificationCenter defaultCenter] postNotificationName:FCMNotificationReceived object:self userInfo:notification.userInfo];
 + }
 + 
 + - (void)application:(UIApplication *)application didReceiveRemoteNotification:(nonnull NSDictionary *)userInfo fetchCompletionHandler:(nonnull void (^)(UIBackgroundFetchResult))completionHandler{


### PR DESCRIPTION
In the README, there is an extra `+` that causes XCode build to fail with the error: `undeclared identifier userInfo`.

Resolves #205 