### PR TITLE
feature(android): add support for badge count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 build
 xcuserdata
+.idea/

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,10 +12,15 @@ android {
     }
 }
 
+repositories {
+    mavenCentral()
+}
+
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile 'com.facebook.react:react-native:+'
     compile 'com.google.firebase:firebase-core:+'
     compile 'com.google.firebase:firebase-messaging:+'
+    compile 'me.leolin:ShortcutBadger:1.1.10@aar'
 }
 

--- a/android/src/main/java/com/evollu/react/fcm/BadgeHelper.java
+++ b/android/src/main/java/com/evollu/react/fcm/BadgeHelper.java
@@ -1,0 +1,43 @@
+package com.evollu.react.fcm;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Log;
+
+import me.leolin.shortcutbadger.ShortcutBadger;
+
+public class BadgeHelper {
+
+    private static final String TAG = "BadgeHelper";
+    private static final String PREFERENCES_FILE = "BadgeCountFile";
+    private static final String BADGE_COUNT_KEY = "BadgeCount";
+
+    private Context mContext;
+    private SharedPreferences sharedPreferences = null;
+
+    public BadgeHelper(Context context) {
+        mContext = context;
+        sharedPreferences = (SharedPreferences) mContext.getSharedPreferences(PREFERENCES_FILE, Context.MODE_PRIVATE);
+    }
+
+    public int getBadgeCount() {
+        return sharedPreferences.getInt(BADGE_COUNT_KEY, 0);
+    }
+
+    public void setBadgeCount(int badgeCount) {
+        storeBadgeCount(badgeCount);
+        if (badgeCount == 0) {
+            ShortcutBadger.removeCount(mContext);
+            Log.d(TAG, "Remove count");
+        } else {
+            ShortcutBadger.applyCount(mContext, badgeCount);
+            Log.d(TAG, "Apply count: " + badgeCount);
+        }
+    }
+
+    private void storeBadgeCount(int badgeCount) {
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+        editor.putInt(BADGE_COUNT_KEY, badgeCount);
+        editor.apply();
+    }
+}

--- a/android/src/main/java/com/evollu/react/fcm/FIRMessagingModule.java
+++ b/android/src/main/java/com/evollu/react/fcm/FIRMessagingModule.java
@@ -36,10 +36,12 @@ import java.util.UUID;
 public class FIRMessagingModule extends ReactContextBaseJavaModule implements LifecycleEventListener, ActivityEventListener {
     private final static String TAG = FIRMessagingModule.class.getCanonicalName();
     private FIRLocalMessagingHelper mFIRLocalMessagingHelper;
+    private BadgeHelper mBadgeHelper;
 
     public FIRMessagingModule(ReactApplicationContext reactContext) {
         super(reactContext);
         mFIRLocalMessagingHelper = new FIRLocalMessagingHelper((Application) reactContext.getApplicationContext());
+        mBadgeHelper = new BadgeHelper(reactContext.getApplicationContext());
         getReactApplicationContext().addLifecycleEventListener(this);
         getReactApplicationContext().addActivityEventListener(this);
         registerTokenRefreshHandler();
@@ -111,6 +113,16 @@ public class FIRMessagingModule extends ReactContextBaseJavaModule implements Li
             array.pushMap(Arguments.fromBundle(bundle));
         }
         promise.resolve(array);
+    }
+
+    @ReactMethod
+    public void setBadgeNumber(int badgeNumber) {
+        mBadgeHelper.setBadgeCount(badgeNumber);
+    }
+
+    @ReactMethod
+    public void getBadgeNumber(Promise promise) {
+       promise.resolve(mBadgeHelper.getBadgeCount());
     }
 
     private void sendEvent(String eventName, Object params) {

--- a/android/src/main/java/com/evollu/react/fcm/MessagingService.java
+++ b/android/src/main/java/com/evollu/react/fcm/MessagingService.java
@@ -23,6 +23,7 @@ public class MessagingService extends FirebaseMessagingService {
     }
 
     public void handleBadge(RemoteMessage remoteMessage) {
+        BadgeHelper badgeHelper = new BadgeHelper(this);
         if (remoteMessage.getData() == null) {
             return;
         }
@@ -34,13 +35,7 @@ public class MessagingService extends FirebaseMessagingService {
 
         try {
             int badgeCount = Integer.parseInt((String)data.get("badge"));
-            if (badgeCount == 0) {
-                ShortcutBadger.removeCount(this);
-                Log.d(TAG, "Remove count");
-            } else {
-                ShortcutBadger.applyCount(this, badgeCount);
-                Log.d(TAG, "Apply count: " + badgeCount);
-            }
+            badgeHelper.setBadgeCount(badgeCount);
         } catch (Exception e) {
             Log.e(TAG, "Badge count needs to be an integer", e);
         }

--- a/android/src/main/java/com/evollu/react/fcm/MessagingService.java
+++ b/android/src/main/java/com/evollu/react/fcm/MessagingService.java
@@ -1,7 +1,9 @@
 package com.evollu.react.fcm;
 
+import java.util.Map;
 import android.content.Intent;
 import android.util.Log;
+import me.leolin.shortcutbadger.ShortcutBadger;
 
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
@@ -16,6 +18,31 @@ public class MessagingService extends FirebaseMessagingService {
         Log.d(TAG, "Remote message received");
         Intent i = new Intent("com.evollu.react.fcm.ReceiveNotification");
         i.putExtra("data", remoteMessage);
+        handleBadge(remoteMessage);
         sendOrderedBroadcast(i, null);
+    }
+
+    public void handleBadge(RemoteMessage remoteMessage) {
+        if (remoteMessage.getData() == null) {
+            return;
+        }
+
+        Map data = remoteMessage.getData();
+        if (data.get("badge") == null) {
+            return;
+        }
+
+        try {
+            int badgeCount = Integer.parseInt((String)data.get("badge"));
+            if (badgeCount == 0) {
+                ShortcutBadger.removeCount(this);
+                Log.d(TAG, "Remove count");
+            } else {
+                ShortcutBadger.applyCount(this, badgeCount);
+                Log.d(TAG, "Apply count: " + badgeCount);
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Badge count needs to be an integer", e);
+        }
     }
 }


### PR DESCRIPTION
Using Leolin's ShortcutBadger we are able to support any badge counts that are sent as part of the notifications data-payload.