### PR TITLE
Fix crash in presentLocalNotification

### DIFF
--- a/ios/RNFIRMesssaging.m
+++ b/ios/RNFIRMesssaging.m
@@ -251,7 +251,7 @@ RCT_EXPORT_METHOD(presentLocalNotification:(UNNotificationRequest *)request reso
       }
     }];
   }else{
-    UILocalNotification* notif = [RCTConvert UILocalNotification:data];
+    UILocalNotification* notif = [RCTConvert UILocalNotification:request];
     [RCTSharedApplication() presentLocalNotificationNow:notif];
     resolve(nil);
   }

--- a/ios/RNFIRMesssaging.m
+++ b/ios/RNFIRMesssaging.m
@@ -240,10 +240,9 @@ RCT_EXPORT_METHOD(unsubscribeFromTopic: (NSString*) topic)
   [_bridge.eventDispatcher sendDeviceEventWithName:FCMNotificationReceived body:[remoteMessage appData]];
 }
 
-RCT_EXPORT_METHOD(presentLocalNotification:(UNNotificationRequest *)data resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(presentLocalNotification:(UNNotificationRequest *)request resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
   if([UNUserNotificationCenter currentNotificationCenter] != nil){
-    UNNotificationRequest* request = [RCTConvert UNNotificationRequest:data];
     [[UNUserNotificationCenter currentNotificationCenter] addNotificationRequest:request withCompletionHandler:^(NSError * _Nullable error) {
       if (!error) {
         resolve(nil);


### PR DESCRIPTION
Crash was caused by passing an invalid type to [RCTConvert UNNotificationRequest:id] which is expecting a dictionary but UNNotificationRequest object was provided