### PR TITLE
Updated readme with instructions for app level build.gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
  dependencies {
      compile project(':react-native-fcm')
 +    compile 'com.google.firebase:firebase-core:10.0.1' //this decides your firebase SDK version
++    compile 'com.google.firebase:firebase-messaging:10.0.1' //this is needed for remote notifications
      compile fileTree(dir: "libs", include: ["*.jar"])
      compile "com.android.support:appcompat-v7:23.0.1"
      compile "com.facebook.react:react-native:+"  // From node_modules


### PR DESCRIPTION
It seems that the following line is needed in order to make push notifications work on Android. This step is documented in the guide below, but not in this repository:
https://firebase.google.com/docs/cloud-messaging/android/client