### PR TITLE
Support install from podfile

### DIFF
--- a/react-native-fcm.podspec
+++ b/react-native-fcm.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/*.{h,m}"
 
   s.dependency "React"
+  s.dependency "Firebase/Messaging"
 end

--- a/react-native-fcm.podspec
+++ b/react-native-fcm.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.requires_arc  = true
   s.homepage      = "https://github.com/evollu/react-native-fcm"
   s.source        = { :git => 'https://github.com/evollu/react-native-fcm.git' }
-  s.platform      = :ios, '7.0'
+  s.platform      = :ios, '8.0'
   s.source_files  = "ios/*.{h,m}"
 
   s.dependency "React"

--- a/react-native-fcm.podspec
+++ b/react-native-fcm.podspec
@@ -1,0 +1,17 @@
+require "json"
+package = JSON.parse(File.read('package.json'))
+
+Pod::Spec.new do |s|
+  s.name          = package['name']
+  s.version       = package['version']
+  s.summary       = package['description']
+  s.author        = "Libin Lu"
+  s.license       = package['license']
+  s.requires_arc  = true
+  s.homepage      = "https://github.com/evollu/react-native-fcm"
+  s.source        = { :git => 'https://github.com/evollu/react-native-fcm.git' }
+  s.platform      = :ios, '7.0'
+  s.source_files  = "ios/*.{h,m}"
+
+  s.dependency "React"
+end


### PR DESCRIPTION
This enables us who like using cocoapods instead of the manual hassle of integrating RN libs to import the project by adding

```
  pod 'react-native-fcm',  path: '../node_modules/react-native-fcm'
```

to the Podfile