### PR TITLE
Fix iOS crash on startup due to wrong thread

### DIFF
--- a/ios/RNFIRMesssaging.m
+++ b/ios/RNFIRMesssaging.m
@@ -160,7 +160,9 @@ RCT_EXPORT_MODULE()
    name:FIRMessagingSendSuccessNotification object:nil];
   
   // For iOS 10 data message (sent via FCM)
-  [[FIRMessaging messaging] setRemoteMessageDelegate:self];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [[FIRMessaging messaging] setRemoteMessageDelegate:self];
+  });
 }
 
 - (void)connectToFCM


### PR DESCRIPTION
Error:

```objc
Assertion failure in -[GIPReachability startWithCompletionHandler:]
'NSInternalInconsistencyException', reason: 'GIPReachability should be used from the main thread'
```

Fixes #233