### PR TITLE
attempt to fix installation with cocoapods

### DIFF
--- a/ios/RNFIRMessaging.h
+++ b/ios/RNFIRMessaging.h
@@ -1,11 +1,7 @@
 
 #import <UIKit/UIKit.h>
 
-#import <FirebaseCore/FirebaseCore.h>
-#import <FirebaseCore/FIRConfiguration.h>
 #import <FirebaseCore/FIRApp.h>
-#import <FirebaseCore/FIRAnalyticsConfiguration.h>
-#import <FirebaseCore/FIROptions.h>
 
 #import <React/RCTBridgeModule.h>
 

--- a/ios/RNFIRMessaging.h
+++ b/ios/RNFIRMessaging.h
@@ -1,7 +1,11 @@
 
 #import <UIKit/UIKit.h>
 
-@import FirebaseCore;
+#import <FirebaseCore/FirebaseCore.h>
+#import <FirebaseCore/FIRConfiguration.h>
+#import <FirebaseCore/FIRApp.h>
+#import <FirebaseCore/FIRAnalyticsConfiguration.h>
+#import <FirebaseCore/FIROptions.h>
 
 #import <React/RCTBridgeModule.h>
 
@@ -13,3 +17,4 @@ extern NSString *const FCMNotificationReceived;
 @property (nonatomic, assign) bool connectedToFCM;
 
 @end
+

--- a/ios/RNFIRMesssaging.m
+++ b/ios/RNFIRMesssaging.m
@@ -5,8 +5,8 @@
 #import <React/RCTUtils.h>
 
 @import UserNotifications;
-@import FirebaseMessaging;
-@import FirebaseInstanceID;
+#import <FirebaseMessaging/FirebaseMessaging.h>
+#import <FirebaseInstanceID/FirebaseInstanceID.h>
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_8_0
 


### PR DESCRIPTION
I use installation with cocoapods. And I have problems with modules import. But import of headers works. Suddenly I can't explain that. This error I've got.
`app/node_modules/react-native-fcm/ios/RNFIRMessaging.h:4:9: Module 'FirebaseCore' not found`. I can provide simple project which shows that bug.

**One small note about cocoapods**: I can't use `use_frameworks` because one of my dependency doesn't work with it and https://github.com/facebook/react-native/issues/11781 react also is not compiling with it.