### PR TITLE
Bugfix/foreground conditions for iOS 10

### DIFF
--- a/Examples/simple-fcm-client/ios/SimpleFcmClient/AppDelegate.m
+++ b/Examples/simple-fcm-client/ios/SimpleFcmClient/AppDelegate.m
@@ -44,7 +44,10 @@
 
 #if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
-  [[NSNotificationCenter defaultCenter] postNotificationName:FCMNotificationReceived object:self userInfo:notification.request.content.userInfo];
+  NSMutableDictionary *userInfo = [[NSMutableDictionary alloc] initWithDictionary: notification.request.content.userInfo];
+  [userInfo setValue:@YES forKey:@"received_in_foreground"];
+  [[NSNotificationCenter defaultCenter] postNotificationName:FCMNotificationReceived object:self userInfo:userInfo];
+  
   if([[notification.request.content.userInfo valueForKey:@"show_in_foreground"] isEqual:@YES]) {
     completionHandler(UNNotificationPresentationOptionAlert | UNNotificationPresentationOptionBadge | UNNotificationPresentationOptionSound);
   } else {

--- a/Examples/simple-fcm-client/package.json
+++ b/Examples/simple-fcm-client/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "react": "15.3.2",
     "react-native": "0.35.0",
-    "react-native-fcm": "^2.3.1"
+    "react-native-fcm": "../../"
   },
   "jest": {
     "preset": "jest-react-native"

--- a/README.md
+++ b/README.md
@@ -191,7 +191,10 @@ Edit `AppDelegate.m`:
 +
 + - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
 + {
-+   [[NSNotificationCenter defaultCenter] postNotificationName:FCMNotificationReceived object:self userInfo:notification.request.content.userInfo];
++   NSDictionary *userInfo = [[NSMutableDictionary alloc] initWithDictionary: notification.request.content.userInfo];
++   [userInfo setValue:@YES forKey:@"received_in_foreground"];
++   [[NSNotificationCenter defaultCenter] postNotificationName:FCMNotificationReceived object:self userInfo:userInfo];
++
 +     if([[notification.request.content.userInfo valueForKey:@"show_in_foreground"] isEqual:@YES]){
 +     completionHandler(UNNotificationPresentationOptionAlert | UNNotificationPresentationOptionBadge | UNNotificationPresentationOptionSound);
 +   }else{

--- a/ios/RNFIRMesssaging.m
+++ b/ios/RNFIRMesssaging.m
@@ -379,7 +379,7 @@ RCT_EXPORT_METHOD(send:(NSString*)senderId withPayload:(NSDictionary *)message)
 
 - (void)handleNotificationReceived:(NSNotification *)notification
 {
-  if([notification.userInfo valueForKey:@"opened_from_tray"] == nil){
+  if([notification.userInfo valueForKey:@"opened_from_tray"] == nil && [notification.userInfo valueForKey:@"received_in_foreground"] == nil){
     NSMutableDictionary *data = [[NSMutableDictionary alloc]initWithDictionary: notification.userInfo];
     [data setValue:@(RCTSharedApplication().applicationState == UIApplicationStateInactive) forKey:@"opened_from_tray"];
     [_bridge.eventDispatcher sendDeviceEventWithName:FCMNotificationReceived body:data];


### PR DESCRIPTION
This PR is mainly to fix the following edge case: 

Expected:
Given an iOS app which has been opened, not been minimised and not fallen into background, 
when the tray has been dragged down open and covered on the app, 
and a new notification has arrived, 
Then the app should behave the same as it receives a notification in foreground. 

Actual: 
Javascript notification listener instantly receive a notification with open_from_tray flag just like an notification has been clicked and the app resumes from background.

Reason:
When the tray covers on the app and a notification arrives, willPresentNotification will get fired as the app is in foreground, however applicationState is already UIApplicationStateInactive like the most case in background. So we need another flag "received_in_foreground" for this foreground edge case.

Tested in iOS 10