### PR TITLE
Upgrade Android build tools to 25.0.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "25.0.1"
 
     defaultConfig {
         minSdkVersion 16
@@ -23,4 +23,3 @@ dependencies {
     compile 'com.google.firebase:firebase-messaging:+'
     compile 'me.leolin:ShortcutBadger:1.1.10@aar'
 }
-


### PR DESCRIPTION
This is generally a good idea. I did it specifically because the latest [Android Gradle plugin 2.3.0](https://developer.android.com/studio/releases/gradle-plugin.html) only supports build tools versions >=25.