### PR TITLE
Fixed Platform not being imported and added a base for FirebaseConstants

### DIFF
--- a/Examples/simple-fcm-client/app/FirebaseConstants.js
+++ b/Examples/simple-fcm-client/app/FirebaseConstants.js
@@ -1,0 +1,6 @@
+
+const FirebaseConstants = {
+	KEY: "YOUR_API_KEY"
+}
+
+export default FirebaseConstants;

--- a/Examples/simple-fcm-client/app/PushController.js
+++ b/Examples/simple-fcm-client/app/PushController.js
@@ -1,5 +1,7 @@
 import React, { Component } from "react";
 
+import { Platform } from 'react-native';
+
 import FCM, {FCMEvent, RemoteNotificationResult, WillPresentNotificationResult, NotificationType} from "react-native-fcm";
 
 import firebaseClient from  "./FirebaseClient";


### PR DESCRIPTION
I found an issue while investigating issue #343 where Platform is not imported from 'react-native' so I imported and added a base FirebaseConstants file for those new to ES6 syntax and React-Native. 