### PR TITLE
Fix of "Key fire_date expected Long but value was a java.lang.Double" exception

### DIFF
--- a/android/src/main/java/com/evollu/react/fcm/FIRLocalMessagingHelper.java
+++ b/android/src/main/java/com/evollu/react/fcm/FIRLocalMessagingHelper.java
@@ -221,7 +221,7 @@ public class FIRLocalMessagingHelper {
             return;
         }
 
-        Long fireDate = bundle.getLong("fire_date", Math.round(bundle.getDouble("fire_date")));
+        Long fireDate = Math.round(bundle.getDouble("fire_date"));
         if (fireDate == 0) {
             Log.e(TAG, "failed to schedule notification because fire date is missing");
             return;


### PR DESCRIPTION
Exception after FCM.scheduleLocalNotification call:

```
Key fire_date expected Long but value was a java.lang.Double.  The default value 1489824292000 was returned.
Attempt to cast generated internal exception:
java.lang.ClassCastException: java.lang.Double cannot be cast to java.lang.Long
	at android.os.BaseBundle.getLong(BaseBundle.java:834)
	at com.evollu.react.fcm.FIRLocalMessagingHelper.sendNotificationScheduled(FIRLocalMessagingHelper.java:224)
	at com.evollu.react.fcm.FIRMessagingModule.scheduleLocalNotification(FIRMessagingModule.java:86)
	at java.lang.reflect.Method.invoke(Native Method)
	at java.lang.reflect.Method.invoke(Method.java:372)
	at com.facebook.react.bridge.BaseJavaModule$JavaMethod.invoke(BaseJavaModule.java:345)
	at com.facebook.react.cxxbridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:136)
	at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
	at android.os.Handler.handleCallback(Handler.java:739)
	at android.os.Handler.dispatchMessage(Handler.java:95)
	at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:31)
	at android.os.Looper.loop(Looper.java:135)
	at com.facebook.react.bridge.queue.MessageQueueThreadImpl$3.run(MessageQueueThreadImpl.java:196)
	at java.lang.Thread.run(Thread.java:818)

```

Removing 'bundle.getLong' fix it.

