### PR TITLE
Added missing push notifications step

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,10 @@ Edit `AppDelegate.m`:
 ```
 
 ### Xcode post installation steps
-- Select your project **Capabilities** and enable **Keychan Sharing** and *Background Modes* > **Remote notifications**.
+- Select your project **Capabilities** and enable:
+  - **Push Notifications**
+  - **Keychain Sharing** 
+  - *Background Modes* > **Remote notifications**.
 
 - In Xcode menu bar, select *Product* > *Scheme* > **Manage schemes**. Select your project name Scheme then click on the minus sign **―** in the bottom left corner, then click on the plus sign **+** and rebuild your project scheme.
 


### PR DESCRIPTION
We were using v2.5.6 and it's definitely required for that version. (It's mentioned briefly in non-cocoapods instructions, but we did cocoa pods and missed it!).

Not sure if later versions don't require this step?