### PR TITLE
Return success/failure on RequestPermissions

### DIFF
--- a/Examples/simple-fcm-client/app/App.js
+++ b/Examples/simple-fcm-client/app/App.js
@@ -14,13 +14,15 @@ import {
 
 import PushController from "./PushController";
 import firebaseClient from  "./FirebaseClient";
+import FCM from "react-native-fcm";
 
 export default class App extends Component {
   constructor(props) {
     super(props);
 
     this.state = {
-      token: ""
+      token: "",
+      requestStatus: "pending"
     }
   }
 
@@ -31,6 +33,8 @@ export default class App extends Component {
       <View style={styles.container}>
         <PushController
           onChangeToken={token => this.setState({token: token || ""})}
+          onPermissionRequest={success =>
+            this.setState({requestStatus: success ? "success" : "failed"})}
         />
         <Text style={styles.welcome}>
           Welcome to Simple Fcm Client!
@@ -39,6 +43,17 @@ export default class App extends Component {
         <Text style={styles.instructions}>
           Token: {this.state.token}
         </Text>
+        
+        <Text style={styles.instructions}>
+          Request status: {this.state.requestStatus}
+        </Text>
+        <TouchableOpacity onPress={() => {
+            FCM.requestPermissions()
+              .catch(() => this.setState({requestStatus: "failed"}))
+              .then(({alert}) => this.setState({requestStatus: alert ? "success" : "failed"}))
+        }} style={styles.button}>
+          <Text style={styles.buttonText}>Request permission</Text>
+        </TouchableOpacity>
 
         <TouchableOpacity onPress={() => firebaseClient.sendNotification(token)} style={styles.button}>
           <Text style={styles.buttonText}>Send Notification</Text>

--- a/Examples/simple-fcm-client/app/PushController.js
+++ b/Examples/simple-fcm-client/app/PushController.js
@@ -12,7 +12,9 @@ export default class PushController extends Component {
   }
 
   componentDidMount() {
-    FCM.requestPermissions();
+    FCM.requestPermissions()
+      .catch(() => this.props.onPermissionRequest(false))
+      .then(({alert}) => this.props.onPermissionRequest(alert));
 
     FCM.getFCMToken().then(token => {
       console.log("TOKEN (getFCMToken)", token);

--- a/Examples/simple-fcm-client/ios/SimpleFcmClient/AppDelegate.m
+++ b/Examples/simple-fcm-client/ios/SimpleFcmClient/AppDelegate.m
@@ -40,6 +40,12 @@
   return YES;
 }
 
+// Required to register for notifications
+- (void)application:(__unused UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
+{
+  [RNFIRMessaging didRegisterUserNotificationSettings:notificationSettings];
+}
+
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
 {
   [RNFIRMessaging willPresentNotification:notification withCompletionHandler:completionHandler];

--- a/Examples/simple-fcm-client/package.json
+++ b/Examples/simple-fcm-client/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "react": "~15.4.0-rc.4",
     "react-native": "^0.40.0",
-    "react-native-fcm": "^6.0.2"
+    "react-native-fcm": "file:../../"
   },
   "jest": {
     "preset": "jest-react-native"

--- a/Examples/simple-fcm-client/yarn.lock
+++ b/Examples/simple-fcm-client/yarn.lock
@@ -2955,9 +2955,8 @@ react-deep-force-update@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.0.1.tgz#f911b5be1d2a6fe387507dd6e9a767aa2924b4c7"
 
-react-native-fcm@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/react-native-fcm/-/react-native-fcm-6.0.2.tgz#432578deaf9ad0fa968424c1babb5563c68eaa7e"
+"react-native-fcm@file:../../":
+  version "6.2.0"
 
 react-native@^0.40.0:
   version "0.40.0"

--- a/README.md
+++ b/README.md
@@ -193,6 +193,11 @@ Edit `AppDelegate.m`:
  }
  
 +
+// Required to register for notifications
++ - (void)application:(__unused UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
++ {
++   [RNFIRMessaging didRegisterUserNotificationSettings:notificationSettings];
++ }
 + - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
 + {
 +   [RNFIRMessaging willPresentNotification:notification withCompletionHandler:completionHandler];

--- a/ios/RNFIRMessaging.h
+++ b/ios/RNFIRMessaging.h
@@ -16,6 +16,7 @@ typedef void (^RCTNotificationResponseCallback)();
 @property (nonatomic, assign) bool connectedToFCM;
 
 #if !TARGET_OS_TV
++ (void)didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings;
 + (void)didReceiveRemoteNotification:(nonnull NSDictionary *)userInfo fetchCompletionHandler:(nonnull RCTRemoteNotificationCallback)completionHandler;
 + (void)didReceiveLocalNotification:(nonnull UILocalNotification *)notification;
 + (void)didReceiveNotificationResponse:(nonnull UNNotificationResponse *)response withCompletionHandler:(nonnull RCTNotificationResponseCallback)completionHandler;


### PR DESCRIPTION
`FCM.requestPermissions` now returns a promise. See https://github.com/evollu/react-native-fcm/issues/373#issuecomment-292776394. 

> 
> I've pulled most of it from the implementation of PushNotificationIOS in react-native. It's currently working but you should know the following:
> 
> * An addition method is required in your `AppDelegate.m` (its also provided in the updated README)
> ```
> + - (void)application:(__unused UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
> + {
> +   [RNFIRMessaging didRegisterUserNotificationSettings:notificationSettings];
> + }
> ```
> 
> * `requestPermissions` now returns a promise on iOS which resolves to a dictionary similarly to PushNotificationIOS (e.g. `{alert: true, ...}`)

NOTE: Also notice that the example is now dependent on the local `react-native-fcm` to make local development easier.