### PR TITLE
Added copy-to-clipboard feature for token

### DIFF
--- a/Examples/simple-fcm-client/app/App.js
+++ b/Examples/simple-fcm-client/app/App.js
@@ -9,7 +9,8 @@ import {
   StyleSheet,
   Text,
   TouchableOpacity,
-  View
+  View,
+  Clipboard
 } from 'react-native';
 
 import PushController from "./PushController";
@@ -20,12 +21,13 @@ export default class App extends Component {
     super(props);
 
     this.state = {
-      token: ""
+      token: "",
+      tokenCopyFeedback: ""
     }
   }
 
   render() {
-    let { token } = this.state;
+    let { token, tokenCopyFeedback } = this.state;
 
     return (
       <View style={styles.container}>
@@ -36,8 +38,12 @@ export default class App extends Component {
           Welcome to Simple Fcm Client!
         </Text>
 
-        <Text style={styles.instructions}>
+        <Text selectable={true} onPress={() => this.setClipboardContent(this.state.token)} style={styles.instructions}>
           Token: {this.state.token}
+        </Text>
+
+        <Text style={styles.feedback}>
+          {this.state.tokenCopyFeedback}
         </Text>
 
         <TouchableOpacity onPress={() => firebaseClient.sendNotification(token)} style={styles.button}>
@@ -53,6 +59,16 @@ export default class App extends Component {
         </TouchableOpacity>
       </View>
     );
+  }
+
+  setClipboardContent(text) {
+    Clipboard.setString(text);
+    this.setState({tokenCopyFeedback: "Token copied to clipboard."});
+    setTimeout(() => {this.clearTokenCopyFeedback()}, 2000);
+  }
+
+  clearTokenCopyFeedback() {
+    this.setState({tokenCopyFeedback: ""});
   }
 }
 
@@ -71,7 +87,12 @@ const styles = StyleSheet.create({
   instructions: {
     textAlign: 'center',
     color: '#333333',
-    marginBottom: 5,
+    marginBottom: 2,
+  },
+  feedback: {
+    textAlign: 'center',
+    color: '#996633',
+    marginBottom: 3,
   },
   button: {
     backgroundColor: "teal",


### PR DESCRIPTION
I believe nobody wants to manually type the lengthy token, so now Users of the Example app can copy the token to clipboard simply by pressing on the token. A feedback message is displayed when the User presses on the token text, indicating the token was copied to the clipboard (so it is a hidden feature but easily found by frustrated Users).