### PR TITLE
Update READ.ME with correct diff for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 - Edit `{YOUR_MAIN_PROJECT}/app/build.gradle`:
 ```diff
  dependencies {
-     compile project(':react-native-fcm')
++    compile project(':react-native-fcm')
 +    compile 'com.google.firebase:firebase-core:10.0.1' //this decides your firebase SDK version
      compile fileTree(dir: "libs", include: ["*.jar"])
      compile "com.android.support:appcompat-v7:23.0.1"


### PR DESCRIPTION
When I first configured react-native-fcm I missed the compile project(':react-native-fcm') line because it's not stated as change in the diff viewer. corrected this