### PR TITLE
Fixed integration of FIRMessagingDelegate for iOS 10 devices

### DIFF
--- a/ios/RNFIRMessaging.h
+++ b/ios/RNFIRMessaging.h
@@ -1,13 +1,13 @@
 
 #import <UIKit/UIKit.h>
-
-#import <FirebaseCore/FIRApp.h>
-
 #import <React/RCTBridgeModule.h>
+#import <FirebaseInstanceID/FirebaseInstanceID.h>
+#import <FirebaseCore/FirebaseCore.h>
+#import <FirebaseMessaging/FirebaseMessaging.h>
 
 @import UserNotifications;
 
-@interface RNFIRMessaging : NSObject <RCTBridgeModule>
+@interface RNFIRMessaging : NSObject <RCTBridgeModule, FIRMessagingDelegate>
 
 typedef void (^RCTRemoteNotificationCallback)(UIBackgroundFetchResult result);
 typedef void (^RCTWillPresentNotificationCallback)(UNNotificationPresentationOptions result);

--- a/ios/RNFIRMessaging.m
+++ b/ios/RNFIRMessaging.m
@@ -222,7 +222,7 @@ RCT_EXPORT_MODULE()
 
 - (void)disconnectFCM
 {
-  [[FIRMessaging messaging] shouldEstablishDirectChannel];
+  [[FIRMessaging messaging] disconnect];
   NSLog(@"Disconnected from FCM");
 }
 


### PR DESCRIPTION
didRefreshRegistrationToken was missing, furthermore the class was not applying to the Protocol FIRMessagingDelegate. 