### PR TITLE
Provide collapse_key, from, mesage_id, and send_time in foreground notificaitons

### DIFF
--- a/android/src/main/java/com/evollu/react/fcm/FIRMessagingModule.java
+++ b/android/src/main/java/com/evollu/react/fcm/FIRMessagingModule.java
@@ -207,6 +207,10 @@ public class FIRMessagingModule extends ReactContextBaseJavaModule implements Li
                     fcmData.putString("action", notification.getClickAction());
                 }
                 params.putMap("fcm", fcmData);
+                params.putString("collapse_key", message.getCollapseKey());
+                params.putString("from", message.getFrom());
+                params.putString("google.message_id", message.getMessageId());
+                params.putDouble("google.sent_time", message.getSentTime());
 
                 if(message.getData() != null){
                     Map<String, String> data = message.getData();


### PR DESCRIPTION
When the app is opened with a notification Intent, the notification contains 'collapse_key', 'google.message_id', 'google.sent_time', 'from'.

When a notification is received while the app is in the foreground, these fields are missing.

This PR adds these fields for the foreground notifications.