### PR TITLE
Fixed path for settings.gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ https://firebase.google.com/docs/cloud-messaging/ios/certs
      compile "com.facebook.react:react-native:+"  // From node_modules
  }
 ```
-- Edit `android/app/settings.gradle`
+- Edit `android/settings.gradle`
 ```diff
   ...
 + include ':react-native-fcm'


### PR DESCRIPTION
From my workspace, this file doesn't exist. It does exist directly on the `android` folder.