### PR TITLE
Delete instanceId function

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,13 @@ class App extends Component {
           my_custom_data_1: 'my_custom_field_value_1',
           my_custom_data_2: 'my_custom_field_value_2'
         });
+
+        FCM.deleteInstanceId().then(()={
+          //Deleted instance id successfully
+          //This will reset Instance ID and revokes all tokens.
+        }).catch(error =>{
+          //Error while deleting instance id 
+        })
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -372,13 +372,15 @@ class App extends Component {
           my_custom_data_1: 'my_custom_field_value_1',
           my_custom_data_2: 'my_custom_field_value_2'
         });
-
-        FCM.deleteInstanceId().then(()={
-          //Deleted instance id successfully
-          //This will reset Instance ID and revokes all tokens.
-        }).catch(error =>{
-          //Error while deleting instance id 
-        })
+        
+        FCM.deleteInstanceId()
+            .then( () => {
+              //Deleted instance id successfully
+              //This will reset Instance ID and revokes all tokens.
+            })
+            .catch(error => {
+              //Error while deleting instance id 
+            });
     }
 }
 ```

--- a/android/src/main/java/com/evollu/react/fcm/FIRMessagingModule.java
+++ b/android/src/main/java/com/evollu/react/fcm/FIRMessagingModule.java
@@ -27,7 +27,7 @@ import android.os.Bundle;
 import android.util.Log;
 
 import android.content.Context;
-
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Set;
@@ -74,6 +74,17 @@ public class FIRMessagingModule extends ReactContextBaseJavaModule implements Li
         promise.resolve(FirebaseInstanceId.getInstance().getToken());
     }
 
+    @ReactMethod
+    public void deleteInstanceId(Promise promise){
+        try {
+            FirebaseInstanceId.getInstance().deleteInstanceId();
+            promise.resolve(null);
+        } catch (IOException e) {
+            e.printStackTrace();
+            promise.reject(e.getCause());
+        }
+    }
+    
     @ReactMethod
     public void presentLocalNotification(ReadableMap details) {
         Bundle bundle = Arguments.toBundle(details);

--- a/android/src/main/java/com/evollu/react/fcm/FIRMessagingModule.java
+++ b/android/src/main/java/com/evollu/react/fcm/FIRMessagingModule.java
@@ -81,7 +81,7 @@ public class FIRMessagingModule extends ReactContextBaseJavaModule implements Li
             promise.resolve(null);
         } catch (IOException e) {
             e.printStackTrace();
-            promise.reject(e.getCause());
+            promise.reject(null,e.getMessage());
         }
     }
     

--- a/index.js
+++ b/index.js
@@ -48,6 +48,10 @@ FCM.getFCMToken = () => {
   return RNFIRMessaging.getFCMToken();
 };
 
+FCM.deleteInstanceId = () =>{
+  return RNFIRMessaging.deleteInstanceId();
+};
+
 FCM.getAPNSToken = () => {
   if (Platform.OS === 'ios') {
     return RNFIRMessaging.getAPNSToken();

--- a/ios/RNFIRMessaging.h
+++ b/ios/RNFIRMessaging.h
@@ -3,7 +3,7 @@
 
 #import <FirebaseCore/FIRApp.h>
 #import <FirebaseMessaging/FirebaseMessaging.h>
-
+#import <FirebaseInstanceID/FirebaseInstanceID.h>
 #import <React/RCTEventEmitter.h>
 
 @import UserNotifications;

--- a/ios/RNFIRMessaging.m
+++ b/ios/RNFIRMessaging.m
@@ -231,6 +231,18 @@ RCT_EXPORT_METHOD(getFCMToken:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromi
     resolve([FIRMessaging messaging].FCMToken);
 }
 
+RCT_EXPORT_METHOD(deleteInstanceId:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+  [[FIRInstanceID instanceID]deleteIDWithHandler:^(NSError * _Nullable error) {
+    
+    if (error != nil) {
+      reject([NSString stringWithFormat:@"%ld",error.code],error.localizedDescription,error);
+    } else {
+      resolve(NULL);
+    }
+  }];
+}
+
 - (void)messaging:(nonnull FIRMessaging *)messaging didRefreshRegistrationToken:(nonnull NSString *)fcmToken {
     [self sendEventWithName:FCMTokenRefreshed body:fcmToken];
 }

--- a/ios/RNFIRMessaging.m
+++ b/ios/RNFIRMessaging.m
@@ -236,9 +236,9 @@ RCT_EXPORT_METHOD(deleteInstanceId:(RCTPromiseResolveBlock)resolve rejecter:(RCT
   [[FIRInstanceID instanceID]deleteIDWithHandler:^(NSError * _Nullable error) {
     
     if (error != nil) {
-      reject([NSString stringWithFormat:@"%ld",error.code],error.localizedDescription,error);
+      reject([NSString stringWithFormat:@"%ld",error.code],error.localizedDescription,nil);
     } else {
-      resolve(NULL);
+      resolve(nil);
     }
   }];
 }


### PR DESCRIPTION
Created function to delete instanceId from both Android and iOS so that new FCM Token can be generated and the old token can be revoked