### PR TITLE
safe FirebaseInstanceId.getInstance() access.

### DIFF
--- a/android/src/main/java/com/evollu/react/fcm/FIRMessagingModule.java
+++ b/android/src/main/java/com/evollu/react/fcm/FIRMessagingModule.java
@@ -70,8 +70,13 @@ public class FIRMessagingModule extends ReactContextBaseJavaModule implements Li
 
     @ReactMethod
     public void getFCMToken(Promise promise) {
-        Log.d(TAG, "Firebase token: " + FirebaseInstanceId.getInstance().getToken());
-        promise.resolve(FirebaseInstanceId.getInstance().getToken());
+        try {
+             Log.d(TAG, "Firebase token: " + FirebaseInstanceId.getInstance().getToken());
+             promise.resolve(FirebaseInstanceId.getInstance().getToken());
+        } catch (Throwable e) {
+             e.printStackTrace();
+             promise.reject(null,e.getMessage());
+        }
     }
 
     @ReactMethod


### PR DESCRIPTION
`FirebaseInstanceId.getInstance()` can throw exceptions. For example if Firebase was not initialized.