### PR TITLE
fix getAPNSToken returning (null)

### DIFF
--- a/android/src/main/java/com/evollu/react/fcm/FIRMessagingPackage.java
+++ b/android/src/main/java/com/evollu/react/fcm/FIRMessagingPackage.java
@@ -24,6 +24,11 @@ public class FIRMessagingPackage implements ReactPackage {
     }
 
     @Override
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
+    }
+ 
+    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Arrays.<ViewManager>asList();
     }

--- a/ios/RNFIRMessaging.m
+++ b/ios/RNFIRMessaging.m
@@ -223,7 +223,13 @@ RCT_EXPORT_METHOD(getInitialNotification:(RCTPromiseResolveBlock)resolve rejecte
 
 RCT_EXPORT_METHOD(getAPNSToken:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-    resolve([FIRMessaging messaging].APNSToken);
+    NSData * deviceToken = [FIRMessaging messaging].APNSToken;
+    const char *data = [deviceToken bytes];
+    NSMutableString *token = [NSMutableString string];
+    for (NSUInteger i = 0; i < [deviceToken length]; i++) {
+        [token appendFormat:@"%02.2hhX", data[i]];
+    }
+    resolve([token copy]);
 }
 
 RCT_EXPORT_METHOD(getFCMToken:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)


### PR DESCRIPTION
to fix issue #510
according to Apple's document, apns device token is a bytes array in DSData. It cannot be converted into NSString with NSUTF8StringEncoding which is RN's default but requires a special converting method.