### PR TITLE
Allow local notification without sound (Android and iOS)

### DIFF
--- a/android/src/main/java/com/evollu/react/fcm/FIRLocalMessagingHelper.java
+++ b/android/src/main/java/com/evollu/react/fcm/FIRLocalMessagingHelper.java
@@ -82,7 +82,6 @@ public class FIRLocalMessagingHelper {
                     .setSubText(bundle.getString("sub_text"))
                     .setGroup(bundle.getString("group"))
                     .setVibrate(new long[]{0, DEFAULT_VIBRATION})
-                    .setSound(RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION))
                     .setExtras(bundle.getBundle("data"));
 
             //priority
@@ -151,14 +150,18 @@ public class FIRLocalMessagingHelper {
             }
 
             //sound
-            String soundName = bundle.getString("sound", "default");
-            if (!soundName.equalsIgnoreCase("default")) {
-                int soundResourceId = res.getIdentifier(soundName, "raw", packageName);
-                if(soundResourceId == 0){
-                    soundName = soundName.substring(0, soundName.lastIndexOf('.'));
-                    soundResourceId = res.getIdentifier(soundName, "raw", packageName);
+            String soundName = bundle.getString("sound");
+            if (soundName != null) {
+                if (soundName.equalsIgnoreCase("default")) {
+                    notification.setSound(RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION));
+                } else {
+                    int soundResourceId = res.getIdentifier(soundName, "raw", packageName);
+                    if (soundResourceId == 0) {
+                        soundName = soundName.substring(0, soundName.lastIndexOf('.'));
+                        soundResourceId = res.getIdentifier(soundName, "raw", packageName);
+                    }
+                    notification.setSound(Uri.parse("android.resource://" + packageName + "/" + soundResourceId));
                 }
-                notification.setSound(Uri.parse("android.resource://" + packageName + "/" + soundResourceId));
             }
 
             //color

--- a/ios/RNFIRMessaging.m
+++ b/ios/RNFIRMessaging.m
@@ -45,9 +45,11 @@ RCT_ENUM_CONVERTER(NSCalendarUnit,
     content.body =[RCTConvert NSString:details[@"body"]];
     NSString* sound = [RCTConvert NSString:details[@"sound"]];
     if(sound != nil){
-        content.sound = [UNNotificationSound soundNamed:sound];
-    }else{
-        content.sound = [UNNotificationSound defaultSound];
+        if ([sound isEqual:@"default"]) {
+            content.sound = [UNNotificationSound defaultSound];
+        } else {
+            content.sound = [UNNotificationSound soundNamed:sound];
+        }
     }
     content.categoryIdentifier = [RCTConvert NSString:details[@"click_action"]];
     content.userInfo = details;


### PR DESCRIPTION
This causes the local notification to have the same behavior as the automatic Firebase notification: If the `sound` property is not set, the notification is muted.

If `default` value is set, the default sound is still considered.

Please let me know if anything else needs to be changed.

Custom sound:
```js
        FCM.presentLocalNotification({
            id: ...                       
            title: ...,                               
            body: ...,                                                            
            sound: "my-custom-sound",
            priority: ..., 
            click_action: ...,   
            my_custom_data: ...,
        });
```

Default sound:
```js
        FCM.presentLocalNotification({
            id: ...                       
            title: ...,                               
            body: ...,                                                            
            sound: "default",
            priority: ..., 
            click_action: ...,   
            my_custom_data: ...,
        });
```

No sound:
```js
        FCM.presentLocalNotification({
            id: ...                       
            title: ...,                               
            body: ...,                                                            
            //sound: "default",
            priority: ..., 
            click_action: ...,   
            my_custom_data: ...,
        });
```

Fixes #441.



