### PR TITLE
Dispatch registerForRemoteNotifications on main thread to prevent runtime warnings 

### DIFF
--- a/ios/RNFIRMessaging.m
+++ b/ios/RNFIRMessaging.m
@@ -293,7 +293,9 @@ RCT_EXPORT_METHOD(requestPermissions:(RCTPromiseResolveBlock)resolve rejecter:(R
 #endif
     }
 
-    [[UIApplication sharedApplication] registerForRemoteNotifications];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[UIApplication sharedApplication] registerForRemoteNotifications];
+    });
 }
 
 RCT_EXPORT_METHOD(subscribeToTopic: (NSString*) topic)


### PR DESCRIPTION
Xcode 9 introduced Main Thread Checker, which detects UI API calls on non-UI threads and can be enabled for debug builds.  It ends up complaining about the invocation of `registerForRemoteNotifications()` on a background thread.  This patch fixes the warnings.

https://stackoverflow.com/questions/44391367/swift-4-uiapplication-registerforremotenotifications-must-be-called-from-mai

