### PR TITLE
Update MessagingService.java

### DIFF
--- a/android/src/main/java/com/evollu/react/fcm/MessagingService.java
+++ b/android/src/main/java/com/evollu/react/fcm/MessagingService.java
@@ -57,6 +57,32 @@ public class MessagingService extends FirebaseMessagingService {
             }
         });
     }
+    
+    public void handleIntent(Intent intent)
+    {
+        try
+        {
+            if (intent.getExtras() != null)
+            {
+                RemoteMessage.Builder builder = new RemoteMessage.Builder("RNFIRMessaging");
+
+                for (String key : intent.getExtras().keySet())
+                {
+                    builder.addData(key, intent.getExtras().get(key).toString());
+                }
+
+                onMessageReceived(builder.build());
+            }
+            else
+            {
+                super.handleIntent(intent);
+            }
+        }
+        catch (Exception e)
+        {
+            super.handleIntent(intent);
+        }
+    }
 
     public void handleBadge(RemoteMessage remoteMessage) {
         BadgeHelper badgeHelper = new BadgeHelper(this);


### PR DESCRIPTION
Allow the app to receive notifications from the `FCMEvent.Notification` event in background mode even if the notification contains the 'notification' object. Normally this is intercepted by Firebase and the react native app will not receive notifications while the app is in background mode.