### PR TITLE
Fix switch cases for all NSCalendarUnits

### DIFF
--- a/ios/RNFIRMessaging.m
+++ b/ios/RNFIRMessaging.m
@@ -82,9 +82,11 @@ RCT_ENUM_CONVERTER(NSCalendarUnit,
         }
         case NSCalendarUnitMonth:{
             unitFlags = NSCalendarUnitDay | NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond;
+            break;
         }
         case NSCalendarUnitYear:{
             unitFlags = NSCalendarUnitMonth | NSCalendarUnitDay | NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond;
+            break;
         }
         default:
             unitFlags = NSCalendarUnitDay | NSCalendarUnitMonth | NSCalendarUnitYear | NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond;


### PR DESCRIPTION
Adding a couple of missing break statements that prevents unitFlags taking the default value when the repeat_interval is month and year. Aso removes a couple of dead code warnings in Xcode.