### PR TITLE
Update README about Android Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ https://github.com/evollu/react-native-fcm/blob/master/Examples/simple-fcm-clien
 - Edit `android/app/build.gradle`. Add at the bottom of the file:
 ```diff
   apply plugin: "com.android.application"
+  // ...
 + apply plugin: 'com.google.gms.google-services'
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ https://github.com/evollu/react-native-fcm/blob/master/Examples/simple-fcm-clien
 - Edit `android/app/build.gradle`. Add at the bottom of the file:
 ```diff
   apply plugin: "com.android.application"
-  // ...
+  ...
 + apply plugin: 'com.google.gms.google-services'
 ```
 


### PR DESCRIPTION
Only a few changes.

> Edit android/app/build.gradle. Add at the bottom of the file:

But this example did not look like.
```diff
  dependencies {
    classpath 'com.android.tools.build:gradle:2.0.0'
+   classpath 'com.google.gms:google-services:3.0.0'
```