### PR TITLE
Bugfixes for sdk-26 branch

### DIFF
--- a/android/src/main/java/com/evollu/react/fcm/FIRMessagingModule.java
+++ b/android/src/main/java/com/evollu/react/fcm/FIRMessagingModule.java
@@ -106,6 +106,7 @@ public class FIRMessagingModule extends ReactContextBaseJavaModule implements Li
             }
             if (mngr.getNotificationChannel(id) != null) {
                 promise.resolve(null);
+                return;
             }
             //
             NotificationChannel channel = new NotificationChannel(

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ FCM.requestPermissions = () => {
 
 FCM.createNotificationChannel = (channel) => {
   if (Platform.OS === 'android') {
-    return RNFIRMessaging.createNotificationChannel();
+    return RNFIRMessaging.createNotificationChannel(channel);
   }
 }
 


### PR DESCRIPTION
Fixes two bugs in the sdk-26 branch: Double resolution of the channel-creation promise and failure to pass options from JS to native