### PR TITLE
Dispatch setApplicationIconBadgeNumber on main thread to prevent runtime warnings

### DIFF
--- a/ios/RNFIRMessaging.m
+++ b/ios/RNFIRMessaging.m
@@ -367,7 +367,9 @@ RCT_EXPORT_METHOD(removeAllDeliveredNotifications)
     if([UNUserNotificationCenter currentNotificationCenter] != nil){
         [[UNUserNotificationCenter currentNotificationCenter] removeAllDeliveredNotifications];
     } else {
-        [RCTSharedApplication() setApplicationIconBadgeNumber: 0];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [RCTSharedApplication() setApplicationIconBadgeNumber: 0];
+        });
     }
 }
 
@@ -416,7 +418,9 @@ RCT_EXPORT_METHOD(getScheduledLocalNotifications:(RCTPromiseResolveBlock)resolve
 
 RCT_EXPORT_METHOD(setBadgeNumber: (NSInteger) number)
 {
-    [RCTSharedApplication() setApplicationIconBadgeNumber:number];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [RCTSharedApplication() setApplicationIconBadgeNumber:number];
+    });
 }
 
 RCT_EXPORT_METHOD(getBadgeNumber: (RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)


### PR DESCRIPTION
This patch prevents the following runtime warnings.

```
2018-01-28 02:58:45.501473+0900 *************[368:47835] [reports] Main Thread Checker: UI API called on a background thread: -[UIApplication setApplicationIconBadgeNumber:]
PID: 368, TID: 47835, Thread name: (none), Queue name: com.facebook.react.RNFIRMessagingQueue, QoS: 0
Backtrace:
4   *************                       0x00000001010de294 -[RNFIRMessaging setBadgeNumber:] + 68
5   CoreFoundation                      0x0000000182691cd0 <redacted> + 144
6   CoreFoundation                      0x000000018257056c <redacted> + 292
7   CoreFoundation                      0x000000018257501c <redacted> + 60
8   *************                       0x0000000100ee2528 -[RCTModuleMethod invokeWithBridge:module:arguments:] + 2064
9   *************                       0x0000000100f739fc _ZN8facebook5reactL11invokeInnerEP9RCTBridgeP13RCTModuleDatajRKN5folly7dynamicE + 664
10  *************                       0x0000000100f7358c _ZZN8facebook5react15RCTNativeModule6invokeEjON5folly7dynamicEiENK3$_0clEv + 132
11  *************                       0x0000000100f734fc ___ZN8facebook5react15RCTNativeModule6invokeEjON5folly7dynamicEi_block_invoke + 28
12  libdispatch.dylib                   0x0000000101b412cc _dispatch_call_block_and_release + 24
13  libdispatch.dylib                   0x0000000101b4128c _dispatch_client_callout + 16
14  libdispatch.dylib                   0x0000000101b4ff80 _dispatch_queue_serial_drain + 696
15  libdispatch.dylib                   0x0000000101b447ec _dispatch_queue_invoke + 332
16  libdispatch.dylib                   0x0000000101b50f6c _dispatch_root_queue_drain_deferred_wlh + 428
17  libdispatch.dylib                   0x0000000101b58020 _dispatch_workloop_worker_thread + 652
18  libsystem_pthread.dylib             0x00000001822aef1c _pthread_wqthread + 932
19  libsystem_pthread.dylib             0x00000001822aeb6c start_wqthread + 4
`````