### PR TITLE
Add Pod paths to header search paths

### DIFF
--- a/ios/RNFIRMessaging.xcodeproj/project.pbxproj
+++ b/ios/RNFIRMessaging.xcodeproj/project.pbxproj
@@ -230,6 +230,7 @@
 					"$(PROJECT_DIR)/../../../ios/Frameworks/**",
 					"$(SRCROOT)/../../../node_modules/react-native-firestack/ios/**",
 					"$(PROJECT_DIR)/../../../ios/Pods/Firebase/**",
+					"$(PROJECT_DIR)/../../../ios/Pods/Headers/Public/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
@@ -257,6 +258,7 @@
 					"$(PROJECT_DIR)/../../../ios/Frameworks/**",
 					"$(SRCROOT)/../../../node_modules/react-native-firestack/ios/**",
 					"$(PROJECT_DIR)/../../../ios/Pods/Firebase/**",
+					"$(PROJECT_DIR)/../../../ios/Pods/Headers/Public/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
By adding the pod paths, we ensure that if dependencies (namely React) are installed *only* via Pod and not via direct linking in the project.