### PR TITLE
Add missing dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ https://github.com/evollu/react-native-fcm/blob/master/Examples/simple-fcm-clien
  dependencies {
 +    compile project(':react-native-fcm')
 +    compile 'com.google.firebase:firebase-core:10.0.1' //this decides your firebase SDK version
++    compile 'com.google.firebase:firebase-messaging:10.0.1'
      compile fileTree(dir: "libs", include: ["*.jar"])
      compile "com.android.support:appcompat-v7:23.0.1"
      compile "com.facebook.react:react-native:+"  // From node_modules


### PR DESCRIPTION
Add a missing dependency for `firebase-messaging` as part of the setup steps.