### PR TITLE
Android actions

### DIFF
--- a/android/src/main/java/com/evollu/react/fcm/SendNotificationTask.java
+++ b/android/src/main/java/com/evollu/react/fcm/SendNotificationTask.java
@@ -217,14 +217,14 @@ public class SendNotificationTask extends AsyncTask<Void, Void, Void> {
                     for (int a = 0; a < actions.length; a++) {
                         String actionValue = actions[a].trim();
                         Intent actionIntent = new Intent(mContext, intentClass);
-                        actionIntent.setAction("com.evollu.react.fcm." + actions[a] + "_ACTION");
+                        actionIntent.setAction("com.evollu.react.fcm." + actionValue + "_ACTIVE");
                         actionIntent.putExtras(bundle);
-                        actionIntent.putExtra("_actionIdentifier", actions[a]);
+                        actionIntent.putExtra("_actionIdentifier", actionValue);
                         actionIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
                         PendingIntent pendingActionIntent = PendingIntent.getActivity(mContext, notificationID, actionIntent,
                                 PendingIntent.FLAG_UPDATE_CURRENT);
 
-                        notification.addAction(1, actions[a], pendingActionIntent);
+                        notification.addAction(1, actionValue, pendingActionIntent);
                     }
                 }
                 

--- a/android/src/main/java/com/evollu/react/fcm/SendNotificationTask.java
+++ b/android/src/main/java/com/evollu/react/fcm/SendNotificationTask.java
@@ -211,6 +211,22 @@ public class SendNotificationTask extends AsyncTask<Void, Void, Void> {
                                                                         PendingIntent.FLAG_UPDATE_CURRENT);
                 
                 notification.setContentIntent(pendingIntent);
+
+                if (bundle.containsKey("actions")) {
+                    String[] actions = bundle.getString("actions").split(",");
+                    for (int a = 0; a < actions.length; a++) {
+                        String actionValue = actions[a].trim();
+                        Intent actionIntent = new Intent(mContext, intentClass);
+                        actionIntent.setAction("com.evollu.react.fcm." + actions[a] + "_ACTION");
+                        actionIntent.putExtras(bundle);
+                        actionIntent.putExtra("_actionIdentifier", actions[a]);
+                        actionIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+                        PendingIntent pendingActionIntent = PendingIntent.getActivity(mContext, notificationID, actionIntent,
+                                PendingIntent.FLAG_UPDATE_CURRENT);
+
+                        notification.addAction(1, actions[a], pendingActionIntent);
+                    }
+                }
                 
                 Notification info = notification.build();
                 

--- a/android/src/main/java/com/evollu/react/fcm/SendNotificationTask.java
+++ b/android/src/main/java/com/evollu/react/fcm/SendNotificationTask.java
@@ -217,7 +217,7 @@ public class SendNotificationTask extends AsyncTask<Void, Void, Void> {
                     for (int a = 0; a < actions.length; a++) {
                         String actionValue = actions[a].trim();
                         Intent actionIntent = new Intent(mContext, intentClass);
-                        actionIntent.setAction("com.evollu.react.fcm." + actionValue + "_ACTIVE");
+                        actionIntent.setAction("com.evollu.react.fcm." + actionValue + "_ACTION");
                         actionIntent.putExtras(bundle);
                         actionIntent.putExtra("_actionIdentifier", actionValue);
                         actionIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);

--- a/android/src/main/java/com/evollu/react/fcm/SendNotificationTask.java
+++ b/android/src/main/java/com/evollu/react/fcm/SendNotificationTask.java
@@ -212,8 +212,8 @@ public class SendNotificationTask extends AsyncTask<Void, Void, Void> {
                 
                 notification.setContentIntent(pendingIntent);
 
-                if (bundle.containsKey("actions")) {
-                    String[] actions = bundle.getString("actions").split(",");
+                if (bundle.containsKey("android_actions")) {
+                    String[] actions = bundle.getString("android_actions").split(",");
                     for (int a = 0; a < actions.length; a++) {
                         String actionValue = actions[a].trim();
                         Intent actionIntent = new Intent(mContext, intentClass);


### PR DESCRIPTION
### Description
Added action buttons generating on Android (iOS-way was described in the [issue](https://github.com/evollu/react-native-fcm/issues/325)).

### How it works
Read the `actions` field in the `custom_notification` object in a remote notification:
```
{
 "to" : "some_token",
 "data" : {
     "custom_notification": {
     	      "actions": "Call, Reject",
	      "color":"#00ACD4",
	      "priority":"max"
    }
 }
}
```
So the result should be a notification with two buttons named `Call`, `Reject`.
When we press the button the `notification` body will contain the `_actionIdentifier` with pointed button name, so we can identify what button was pressed. For example, if we press `Call`, the `_actionIdentifier` also will be `Call`.