### PR TITLE
Remove icon from addAction

### DIFF
--- a/android/src/main/java/com/evollu/react/fcm/SendNotificationTask.java
+++ b/android/src/main/java/com/evollu/react/fcm/SendNotificationTask.java
@@ -232,7 +232,7 @@ public class SendNotificationTask extends AsyncTask<Void, Void, Void> {
                         PendingIntent pendingActionIntent = PendingIntent.getActivity(mContext, notificationID, actionIntent,
                                 PendingIntent.FLAG_UPDATE_CURRENT);
 
-                        notification.addAction(1, actionTitle, pendingActionIntent);
+                        notification.addAction(0, actionTitle, pendingActionIntent);
                     }
                 }
                 


### PR DESCRIPTION
## Description
In my case, when I'm trying to send a notification with `android_actions` payload, the app crashes because it tries to find the icon.

```
couldn't inflate view for notification com.myapp/0x2e37b245
                                            android.content.res.Resources$NotFoundException: Resource ID #0x1
                                                at android.content.res.Resources.getValue(Resources.java:2452)
                                                at android.content.res.Resources.getDrawable(Resources.java:1947)
                                                at android.content.Context.getDrawable(Context.java:409)
```
And then:
```
FATAL EXCEPTION: main
                                                                        Process: com.myapp, PID: 18384
                                                                        android.app.RemoteServiceException: Bad notification 
posted from package com.myapp: Couldn't expand RemoteViews for: 
StatusBarNotification(pkg=com.myapp user=UserHandle{0} id=775402053 tag=null score=20 
key=0|com.myapp|775402053|null|10278: Notification(pri=2 contentView=com.myapp/0x109009e 
vibrate=[0,300] sound=null defaults=0x0 flags=0x10 color=0xff00acd4 category=call actions=2 
originalPackageName=N originalUserId=0 vis=PRIVATE))
                                                                            
```
As we have a line: `notification.addAction(1, actionTitle, pendingActionIntent);`
The `1` in this case points an unexisted path to icon (`Resource ID #0x1`).

## Solution
- Changed the icon argument to `0`.