### PR TITLE
Fixed processDebugGoogleServices building error

### DIFF
--- a/Examples/simple-fcm-client/android/app/build.gradle
+++ b/Examples/simple-fcm-client/android/app/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: "com.android.application"
-apply plugin: "com.google.gms.google-services"
 
 import com.android.build.OutputFile
 
@@ -145,3 +144,5 @@ task copyDownloadableDepsToLibs(type: Copy) {
   from configurations.compile
   into 'libs'
 }
+
+apply plugin: "com.google.gms.google-services"


### PR DESCRIPTION
1. Move the google-services plugin to the bottom to avoid a building time error
2. Error message: app:processDebugGoogleServices FAILED