### PR TITLE
Separates versioning for firebase-core and firebase-messaging.  These…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,6 +4,8 @@ def DEFAULT_COMPILE_SDK_VERSION             = 26
 def DEFAULT_BUILD_TOOLS_VERSION             = "25.0.2"
 def DEFAULT_TARGET_SDK_VERSION              = 26
 def DEFAULT_GOOGLE_PLAY_SERVICES_VERSION    = "12.+"
+def DEFAULT_FIREBASE_CORE_VERSION           = "12.+"
+def DEFAULT_FIREBASE_MESSAGING_VERSION      = "12.+"
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? project.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
@@ -23,11 +25,13 @@ repositories {
 
 dependencies {
     def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : DEFAULT_GOOGLE_PLAY_SERVICES_VERSION
+    def firebaseCoreVersion = project.hasProperty('firebaseCoreVersion') ? project.firebaseCoreVersion : DEFAULT_FIREBASE_CORE_VERSION
+    def firebaseMessagingVersion = project.hasProperty('firebaseMessagingVersion') ? project.firebaseMessagingVersion : DEFAULT_FIREBASE_MESSAGING_VERSION
 
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile 'com.facebook.react:react-native:+'
-    compile "com.google.firebase:firebase-core:$googlePlayServicesVersion"
-    compile "com.google.firebase:firebase-messaging:$googlePlayServicesVersion"
+    compile "com.google.firebase:firebase-core:$firebaseCoreVersion"
+    compile "com.google.firebase:firebase-messaging:$firebaseMessagingVersion"
     compile 'me.leolin:ShortcutBadger:1.1.17@aar'
     compile "com.android.support:support-core-utils:26.1.0"
 }


### PR DESCRIPTION
You can no longer assume that firebase has a version for every version of Google play services.  For example, there is no valid 15.0.1 version of firebase-core, even though that is a valid Google Play service version.  The googlePlayServicesVersion needs to be set for other libraries, decoupling the version locking with this PR.