### PR TITLE
Fix Android rescheduled notifications firing immediately

### DIFF
--- a/android/src/main/java/com/evollu/react/fcm/FIRLocalMessagingHelper.java
+++ b/android/src/main/java/com/evollu/react/fcm/FIRLocalMessagingHelper.java
@@ -58,11 +58,11 @@ public class FIRLocalMessagingHelper {
             return;
         }
 
-        long fireDate = Math.round(bundle.getDouble("fire_date"));
-        if(fireDate == 0){
-            fireDate = Math.round(bundle.getLong("fire_date"));
+        Long fireDate = bundle.getLong("fire_date", -1);
+        if (fireDate == -1) {
+            fireDate = (long) bundle.getDouble("fire_date", -1);
         }
-        if (fireDate == 0) {
+        if (fireDate == -1) {
             Log.e(TAG, "failed to schedule notification because fire date is missing");
             return;
         }


### PR DESCRIPTION
Reference: https://github.com/invertase/react-native-firebase/pull/1035/

This will fix scheduled notifications firing immediately after phone restart / opening the app after restart.

Tested with Android 8, 7 and 5 devices. 