### PR TITLE
Bump Android version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
-def DEFAULT_COMPILE_SDK_VERSION             = 27
-def DEFAULT_BUILD_TOOLS_VERSION             = "27.0.3"
-def DEFAULT_TARGET_SDK_VERSION              = 27
+def DEFAULT_COMPILE_SDK_VERSION             = 28
+def DEFAULT_BUILD_TOOLS_VERSION             = "28.0.2"
+def DEFAULT_TARGET_SDK_VERSION              = 28
 def DEFAULT_GOOGLE_PLAY_SERVICES_VERSION    = "+"
 def DEFAULT_FIREBASE_CORE_VERSION           = "+"
 def DEFAULT_FIREBASE_MESSAGING_VERSION      = "+"
@@ -33,5 +33,5 @@ dependencies {
     compile "com.google.firebase:firebase-core:$firebaseCoreVersion"
     compile "com.google.firebase:firebase-messaging:$firebaseMessagingVersion"
     compile 'me.leolin:ShortcutBadger:1.1.17@aar'
-    compile "com.android.support:support-core-utils:27.1.1"
+    compile "com.android.support:support-core-utils:28.0.0"
 }


### PR DESCRIPTION
Bump Android build tools version to 28.x and support-core-utils to 28.0.0.

This PR fixes a bug:

`Could not find com.android.support:support-core-utils:27.1.1`

It seems that `support-core-utils` 27.1.1 is not on maven anymore. Bumping to 28.0.0 fixed it.

 when I use it with `react-native-fast-image`. Anyway the dependencies should be upgraded, as 28.0.0 stable is released.

