### PR TITLE
Fix FIRMessagingDelegate requirements

### DIFF
--- a/ios/RNFIRMessaging.m
+++ b/ios/RNFIRMessaging.m
@@ -460,6 +460,11 @@ RCT_EXPORT_METHOD(deleteInstanceId:(RCTPromiseResolveBlock)resolve rejecter:(RCT
   [self sendEventWithName:FCMTokenRefreshed body:fcmToken];
 }
 
+- (void)messaging:(nonnull FIRMessaging *)messaging didRefreshRegistrationToken:(nonnull NSString *)fcmToken {
+  refreshToken = fcmToken;
+  [self sendEventWithName:FCMTokenRefreshed body:fcmToken];
+}
+
 RCT_EXPORT_METHOD(requestPermissions:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
     if (RCTRunningInAppExtension()) {


### PR DESCRIPTION
The latest updates of Firebase/Messaging use a new method as a requirement of the FIRMessagingDelegate for iOS. This PR includes that method in addition to the old one.