### PR TITLE
Allow channel name/description change

### DIFF
--- a/android/src/main/java/com/evollu/react/fcm/FIRMessagingModule.java
+++ b/android/src/main/java/com/evollu/react/fcm/FIRMessagingModule.java
@@ -105,11 +105,6 @@ public class FIRMessagingModule extends ReactContextBaseJavaModule implements Li
                 default:
                     importance = NotificationManager.IMPORTANCE_DEFAULT;
             }
-            if (mngr.getNotificationChannel(id) != null) {
-                promise.resolve(null);
-                return;
-            }
-            //
             NotificationChannel channel = new NotificationChannel(
                     id,
                     name,


### PR DESCRIPTION
Removed the early return. Calling `createNotificationChannel` multiple times is safe, and will update the name/description if they've changed. 

NB Importance can't be updated as the user may have chosen their own setting here